### PR TITLE
Fixing file path issue to run on Windows

### DIFF
--- a/lib/generator/index.js
+++ b/lib/generator/index.js
@@ -69,8 +69,9 @@ export const generateTestFile = (editor = {}) => {
   // user settings
   const { testDirName, testSufix, typeSystem } = getUserSettings();
   // file info: Name, path
-  const srcFileName = getFileName(editor.getTitle()); // fileName without extension
-  const filePath = getFilePath(editor.getPath(), "/"); // The dir the file is located
+  const auxPathName = editor.getPath().replace(/\\/g, "/");
+  const srcFileName = getFileName(auxPathName); // fileName without extension
+  const filePath = getFilePath(auxPathName); // The dir the file is located
 
   // generated test info: testFileName, saveLocation for test
   const testFileName = `${srcFileName}${testSufix}.js`;


### PR DESCRIPTION
The plugin was unable to run on Windows due to an issue with directory separator characters:

![image](https://user-images.githubusercontent.com/940927/99641613-4388da00-2a29-11eb-9642-36b54ae67602.png)

These changes fixed the problem.

The source file name is now extracted from editor.getPath() since, eventually, Atom adds other informational text to the title, so, it was unsafe to use the window title to infer the file name. All backslashes '\\' characters are replaced by forward slashes '/' prior to split the file path and name, this allow the plugin to properly deal with paths in Windows.